### PR TITLE
fix: example messages

### DIFF
--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -18,7 +18,7 @@ func main() {
 
 	router.On(func(sender *router.NetworkClient, message shared.TestMessage) {
 		log.Println("Testmessage: ", message)
-		sender.SendMessage(shared.TestMessage{"This is from the client"})
+		sender.SendMessage(shared.TestMessage{Message: "This is from the client"})
 	})
 
 	err := client.Start(func(conn *websocket.Conn) {

--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -1,15 +1,13 @@
 package main
 
 import (
+	"log"
+
+	"github.com/leap-fish/necs/examples/shared"
 	"github.com/leap-fish/necs/router"
 	"github.com/leap-fish/necs/transports"
-	"log"
 	"nhooyr.io/websocket"
 )
-
-type TestMessage struct {
-	Message string
-}
 
 func main() {
 	client := transports.NewWsClientTransport("ws://localhost:7373")
@@ -18,9 +16,9 @@ func main() {
 		log.Println("Connected to the server!")
 	})
 
-	router.On[TestMessage](func(sender *router.NetworkClient, message TestMessage) {
+	router.On(func(sender *router.NetworkClient, message shared.TestMessage) {
 		log.Println("Testmessage: ", message)
-		sender.SendMessage(TestMessage{"This is from the client"})
+		sender.SendMessage(shared.TestMessage{"This is from the client"})
 	})
 
 	err := client.Start(func(conn *websocket.Conn) {

--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -21,6 +21,10 @@ func main() {
 		sender.SendMessage(shared.TestMessage{Message: "This is from the client"})
 	})
 
+	router.OnError(func(sender *router.NetworkClient, err error) {
+		log.Printf("Message Error: %s", err.Error())
+	})
+
 	err := client.Start(func(conn *websocket.Conn) {
 		// If you want to use the connection for other purposes, this is where you might want to
 		// store it for later use.

--- a/examples/server/server.go
+++ b/examples/server/server.go
@@ -1,27 +1,25 @@
 package main
 
 import (
+	"log"
+
+	"github.com/leap-fish/necs/examples/shared"
 	"github.com/leap-fish/necs/router"
 	"github.com/leap-fish/necs/transports"
-	"log"
 )
-
-type TestMessage struct {
-	Message string
-}
 
 func main() {
 	router.OnConnect(func(sender *router.NetworkClient) {
 		log.Println("Client has connected to the server!")
 
-		_ = sender.SendMessage(TestMessage{Message: "Hello from server"})
+		_ = sender.SendMessage(shared.TestMessage{Message: "Hello from server"})
 	})
 
 	router.OnDisconnect(func(sender *router.NetworkClient, err error) {
 		log.Println("Client has disconnected!")
 	})
 
-	router.On[TestMessage](func(sender *router.NetworkClient, message TestMessage) {
+	router.On(func(sender *router.NetworkClient, message shared.TestMessage) {
 		log.Println("Testmessage: ", message)
 	})
 

--- a/examples/server/server.go
+++ b/examples/server/server.go
@@ -23,10 +23,13 @@ func main() {
 		log.Println("Testmessage: ", message)
 	})
 
+	router.OnError(func(sender *router.NetworkClient, err error) {
+		log.Printf("Message Error: %s", err.Error())
+	})
+
 	server := transports.NewWsServerTransport(7373, "", nil)
 	err := server.Start()
 	if err != nil {
 		log.Fatalf("Unable to dial: %s", err)
 	}
-
 }

--- a/examples/shared/message.go
+++ b/examples/shared/message.go
@@ -1,9 +1,5 @@
 package shared
 
-import "github.com/yohamta/donburi"
-
 type TestMessage struct {
 	Message string
 }
-
-var TestMessageComponent = donburi.NewComponentType[TestMessage]()

--- a/examples/shared/message.go
+++ b/examples/shared/message.go
@@ -1,0 +1,9 @@
+package shared
+
+import "github.com/yohamta/donburi"
+
+type TestMessage struct {
+	Message string
+}
+
+var TestMessageComponent = donburi.NewComponentType[TestMessage]()


### PR DESCRIPTION
Use a shared message type to prevent `Message Error: callback type not registered: component type not found for ID 7783821856285832660` errors in example.

Resolves: #2 